### PR TITLE
fix:[DMP-432] Added MailTo component to launch email when clicking email

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,9 +1,10 @@
-import { useNavigate, Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { useContext, useState } from "react";
 import UserContext from "config/userContext";
 import Button from "components/common/Button";
 import styles from "./Footer.module.scss";
 import Tooltip from "components/common/Tooltip";
+import MailTo from "components/common/MailTo";
 
 const Footer: React.FC = () => {
   const navigate = useNavigate();
@@ -26,16 +27,9 @@ const Footer: React.FC = () => {
       <div className={styles.title}>Soporte</div>
       <div className={styles["tooltip-text"]}>
         <p>Envianos tus dudas a: </p>
-        <Link
-          className={styles["copy-email"]}
-          to="#"
-          onClick={(e) => {
-            window.location.href = "ejemplo@correo.com";
-            e.preventDefault();
-          }}
-        >
-          {"ejemplo@correo.com"}
-        </Link>
+        <MailTo email="ejemplo@correo.com">
+        {"ejemplo@correo.com"}
+        </MailTo>
       </div>
     </div>
   );

--- a/src/components/common/MailTo/MailTo.module.scss
+++ b/src/components/common/MailTo/MailTo.module.scss
@@ -1,0 +1,16 @@
+@use "styles/colors";
+@use "styles/typography";
+
+.mail{
+    color: colors.$accent;
+    background-color: transparent;
+}
+
+.mail:visited {
+    color: colors.$accent;
+    background-color: transparent;
+}
+
+.mail:active {
+    color: colors.$accent;
+}

--- a/src/components/common/MailTo/MailTo.tsx
+++ b/src/components/common/MailTo/MailTo.tsx
@@ -1,0 +1,16 @@
+import styles from "./MailTo.module.scss";
+
+interface MailToProps {
+  children?: React.ReactNode;
+  email: string;
+}
+
+const MailTo: React.FC<MailToProps> = ({ children, email }) => {
+  return (
+    <a className={styles.mail} href={`mailto:${email}`}>
+      {children}
+    </a>
+  );
+};
+
+export default MailTo;

--- a/src/components/common/MailTo/__tests__/MailTo.test.tsx
+++ b/src/components/common/MailTo/__tests__/MailTo.test.tsx
@@ -1,0 +1,12 @@
+import renderer from "react-test-renderer";
+import MailTo from "../MailTo";
+
+const MailToMockProps = {
+  title: "Mock Title",
+  imgSrc: "./mock/image/route",
+};
+it("renders MailTo with no issue", () => {
+  const component = renderer.create(<MailTo email="contact@example.com" subject= "Hello" body="hello"/>);
+  let tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/components/common/MailTo/__tests__/__snapshots__/MailTo.test.tsx.snap
+++ b/src/components/common/MailTo/__tests__/__snapshots__/MailTo.test.tsx.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders MailTo with no issue 1`] = `
+<a
+  className="mail"
+  href="mailto:contact@example.com"
+/>
+`;

--- a/src/components/common/MailTo/index.ts
+++ b/src/components/common/MailTo/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MailTo";


### PR DESCRIPTION
## What is done

[[DMP-458] Click on email logout](https://deacero.atlassian.net/browse/DMP-458)

## How is done

- Created a `MailTo` component that will be used for when we need to click on an email.

## How to test

1. Run the project via `npm start`
2. Login.
3. On footer click on contactar soporte.
4. Click on email.